### PR TITLE
Serialize scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.swp
 
 *.sqlite
+
+.rubocop-https---raw-githubusercontent-com-everypolitician-everypolitician-data-master--rubocop-base-yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+AllCops:
+  Exclude:
+    - 'Vagrantfile'
+    - 'vendor/**/*'
+  TargetRubyVersion: 2.3
+
+inherit_from:
+  - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml
+  - .rubocop_todo.yml
+
+Style/AndOr:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
+ruby '2.3.1'
+
+gem 'colorize'
+gem 'field_serializer', github: 'everypolitician/field_serializer'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'pry'
+gem 'require_all'
+gem 'rubocop'
+gem 'scraped_page', github: 'everypolitician/scraped_page'
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby', branch: 'morph_defaults'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,96 @@
+GIT
+  remote: https://github.com/everypolitician/field_serializer.git
+  revision: a09f9a73655558190e169d5cae2738a9006fd833
+  specs:
+    field_serializer (0.2.0)
+
+GIT
+  remote: https://github.com/everypolitician/scraped_page.git
+  revision: 6eb806c01e8b9f3e333575a639e40a68be60ae48
+  specs:
+    scraped_page (0.1.0)
+      field_serializer
+      nokogiri
+      scraped_page_archive (>= 0.5)
+
+GIT
+  remote: https://github.com/openaustralia/scraperwiki-ruby.git
+  revision: fc50176812505e463077d5c673d504a6a234aa78
+  branch: morph_defaults
+  specs:
+    scraperwiki (3.0.1)
+      httpclient
+      sqlite_magic
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    ast (2.3.0)
+    coderay (1.1.1)
+    colorize (0.8.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
+    httpclient (2.8.2.4)
+    method_source (0.8.2)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    open-uri-cached (0.0.5)
+    parser (2.3.1.4)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (2.0.4)
+    rainbow (2.1.0)
+    require_all (1.3.3)
+    rubocop (0.45.0)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+    slop (3.6.0)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
+      sqlite3
+    unicode-display_width (1.1.1)
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  colorize
+  field_serializer!
+  nokogiri
+  open-uri-cached
+  pry
+  require_all
+  rubocop
+  scraped_page!
+  scraperwiki!
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.13.6

--- a/lib/member_entry.rb
+++ b/lib/member_entry.rb
@@ -18,10 +18,6 @@ class MemberEntry
       .gsub(/\s*,\s*MP\s*$/, '')
   end
 
-  field :photo do
-    noko.css('div.field-content img/@src').text
-  end
-
   field :constituency do
     noko
       .css('span.views-field-field-constituency-name .field-content')

--- a/lib/member_entry.rb
+++ b/lib/member_entry.rb
@@ -18,6 +18,29 @@ class MemberEntry
       .gsub(/\s*,\s*MP\s*$/, '')
   end
 
+  field :photo do
+    noko.css('div.field-content img/@src').text
+  end
+
+  field :constituency do
+    noko
+      .css('span.views-field-field-constituency-name .field-content')
+      .text
+      .strip
+  end
+
+  field :party do
+    split_party.first
+  end
+
+  field :party_id do
+    split_party.last
+  end
+
+  field :source do
+    url
+  end
+
   private
 
   attr_reader :url, :noko

--- a/lib/member_entry.rb
+++ b/lib/member_entry.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class MemberEntry
+  include FieldSerializer
+
+  def initialize(url:, noko:)
+    @url  = url
+    @noko = noko
+  end
+
+  field :name do
+    noko
+      .css('.views-field-view-node a')
+      .text
+      .split(/\s+/)
+      .join(' ')
+      .strip
+      .gsub(/\s*,\s*MP\s*$/, '')
+  end
+
+  private
+
+  attr_reader :url, :noko
+
+  def split_party
+    @split_party ||= noko
+                     .css('.views-field-field-political-party .field-content')
+                     .text
+                     .strip
+                     .match(/(.*) \((.*)\)/)
+                     .captures
+  end
+end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -5,4 +5,11 @@ class MemberPage < ScrapedPage
   field :id do
     url.to_s.split('/').last
   end
+
+  field :email do
+    noko
+      .css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]')
+      .text
+      .strip
+  end
 end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -32,6 +32,10 @@ class MemberPage < ScrapedPage
       .strip
   end
 
+  field :party do
+    split_party.first
+  end
+
   field :email do
     noko
       .css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]')
@@ -47,7 +51,20 @@ class MemberPage < ScrapedPage
       .first
   end
 
+  field :party_id do
+    split_party.last
+  end
+
   private
 
   attr_reader :entry
+
+  def split_party
+    @split_party ||= entry
+                     .css('.views-field-field-political-party .field-content')
+                     .text
+                     .strip
+                     .match(/(.*) \((.*)\)/)
+                     .captures
+  end
 end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -22,6 +22,6 @@ class MemberPage < ScrapedPage
   end
 
   field :term do
-    2011
+    2016
   end
 end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -55,6 +55,14 @@ class MemberPage < ScrapedPage
     split_party.last
   end
 
+  field :source do
+    URI.join(url, '/members-of-parliament').to_s
+  end
+
+  field :term do
+    2011
+  end
+
   private
 
   attr_reader :entry

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -11,16 +11,6 @@ class MemberPage < ScrapedPage
     url.to_s.split('/').last
   end
 
-  field :name do
-    entry
-      .css('.views-field-view-node a')
-      .text
-      .split(/\s+/)
-      .join(' ')
-      .strip
-      .gsub(/\s*,\s*MP\s*$/, '')
-  end
-
   field :photo do
     entry.css('div.field-content img/@src').text
   end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -2,8 +2,23 @@
 require 'scraped_page'
 
 class MemberPage < ScrapedPage
+  def initialize(url:, strategy: Strategy::LiveRequest.new, entry:)
+    @entry = entry
+    super(url: url, strategy: strategy)
+  end
+
   field :id do
     url.to_s.split('/').last
+  end
+
+  field :name do
+    entry
+      .css('.views-field-view-node a')
+      .text
+      .split(/\s+/)
+      .join(' ')
+      .strip
+      .gsub(/\s*,\s*MP\s*$/, '')
   end
 
   field :email do
@@ -20,4 +35,8 @@ class MemberPage < ScrapedPage
       .split('T')
       .first
   end
+
+  private
+
+  attr_reader :entry
 end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -12,4 +12,12 @@ class MemberPage < ScrapedPage
       .text
       .strip
   end
+
+  field :birth_date do
+    noko
+      .css('.field-name-field-date .field-item .date-display-single/@content')
+      .text
+      .split('T')
+      .first
+  end
 end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -6,6 +6,10 @@ class MemberPage < ScrapedPage
     url.to_s.split('/').last
   end
 
+  field :photo do
+    noko.css('.panels-flexible-region-1-picture img/@src').first.text rescue ""
+  end
+
   field :email do
     noko
       .css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]')

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -2,28 +2,8 @@
 require 'scraped_page'
 
 class MemberPage < ScrapedPage
-  def initialize(url:, strategy: Strategy::LiveRequest.new, entry:)
-    @entry = entry
-    super(url: url, strategy: strategy)
-  end
-
   field :id do
     url.to_s.split('/').last
-  end
-
-  field :photo do
-    entry.css('div.field-content img/@src').text
-  end
-
-  field :constituency do
-    entry
-      .css('span.views-field-field-constituency-name .field-content')
-      .text
-      .strip
-  end
-
-  field :party do
-    split_party.first
   end
 
   field :email do
@@ -41,28 +21,7 @@ class MemberPage < ScrapedPage
       .first
   end
 
-  field :party_id do
-    split_party.last
-  end
-
-  field :source do
-    URI.join(url, '/members-of-parliament').to_s
-  end
-
   field :term do
     2011
-  end
-
-  private
-
-  attr_reader :entry
-
-  def split_party
-    @split_party ||= entry
-                     .css('.views-field-field-political-party .field-content')
-                     .text
-                     .strip
-                     .match(/(.*) \((.*)\)/)
-                     .captures
   end
 end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -25,6 +25,13 @@ class MemberPage < ScrapedPage
     entry.css('div.field-content img/@src').text
   end
 
+  field :constituency do
+    entry
+      .css('span.views-field-field-constituency-name .field-content')
+      .text
+      .strip
+  end
+
   field :email do
     noko
       .css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]')

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -11,10 +11,7 @@ class MemberPage < ScrapedPage
   end
 
   field :email do
-    noko
-      .css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]')
-      .text
-      .strip
+    noko.css('.field-name-field-email .field-item a').map(&:text).join(';')
   end
 
   field :birth_date do

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -14,6 +14,22 @@ class MemberPage < ScrapedPage
     noko.css('.field-name-field-email .field-item a').map(&:text).join(';')
   end
 
+  field :phone do
+    noko.css('.field-name-field-telephone .field-item').map(&:text).join(';')
+  end
+
+  field :cell do
+    noko.css('.field-name-field-phone-number .field-item').map(&:text).join(';')
+  end
+
+  field :fax do
+    noko.css('.field-name-field-fax-number .field-item').map(&:text).join(';')
+  end
+
+  field :address do
+    noko.css('.field-name-field-postal-address .field-item').text rescue ""
+  end
+
   field :birth_date do
     noko
       .css('.field-name-field-date .field-item .date-display-single/@content')

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'scraped_page'
+
+class MemberPage < ScrapedPage
+  field :id do
+    url.to_s.split('/').last
+  end
+end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -21,6 +21,10 @@ class MemberPage < ScrapedPage
       .gsub(/\s*,\s*MP\s*$/, '')
   end
 
+  field :photo do
+    entry.css('div.field-content img/@src').text
+  end
+
   field :email do
     noko
       .css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]')

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -28,6 +28,10 @@ class MembersPage < ScrapedPage
       .gsub(/\s*,\s*MP\s*$/, '')
   end
 
+  def photo(entry)
+    entry.css('div.field-content img/@src').text
+  end
+
   private
 
   def split_party(entry)

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -2,7 +2,7 @@
 require 'scraped_page'
 
 class MembersPage < ScrapedPage
-  def mp_entries
+  field :mp_entries do
     noko.css('.view-members-of-parliament .panel-display')
   end
 

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -9,4 +9,23 @@ class MembersPage < ScrapedPage
   def mp_url(entry)
     URI.join(url, entry.css('.views-field-view-node a/@href').text).to_s
   end
+
+  def party_name(entry)
+    split_party(entry).first
+  end
+
+  def party_id(entry)
+    split_party(entry).last
+  end
+
+  private
+
+  def split_party(entry)
+    @split_party ||= entry
+                     .css('span.views-field-field-political-party .field-content')
+                     .text
+                     .strip
+                     .match(/(.*) \((.*)\)/)
+                     .captures
+  end
 end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -18,16 +18,6 @@ class MembersPage < ScrapedPage
     split_party(entry).last
   end
 
-  def name(entry)
-    entry
-      .css('.views-field-view-node a')
-      .text
-      .split(/\s+/)
-      .join(' ')
-      .strip
-      .gsub(/\s*,\s*MP\s*$/, '')
-  end
-
   def photo(entry)
     entry.css('div.field-content img/@src').text
   end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -5,4 +5,8 @@ class MembersPage < ScrapedPage
   def mp_entries
     noko.css('.view-members-of-parliament .panel-display')
   end
+
+  def mp_url(entry)
+    URI.join(url, entry.css('.views-field-view-node a/@href').text).to_s
+  end
 end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'scraped_page'
+
+class MembersPage < ScrapedPage
+  def mp_entries
+    noko.css('.view-members-of-parliament .panel-display')
+  end
+end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -18,6 +18,16 @@ class MembersPage < ScrapedPage
     split_party(entry).last
   end
 
+  def name(entry)
+    entry
+      .css('.views-field-view-node a')
+      .text
+      .split(/\s+/)
+      .join(' ')
+      .strip
+      .gsub(/\s*,\s*MP\s*$/, '')
+  end
+
   private
 
   def split_party(entry)

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -6,6 +6,12 @@ class MembersPage < ScrapedPage
     noko.css('.view-members-of-parliament .panel-display')
   end
 
+  field :next_page_url do
+    path = noko.css('.pager-next a/@href').text
+    return if path.empty?
+    URI.join(url, URI.encode(URI.decode(path))).to_s
+  end
+
   def mp_url(entry)
     URI.join(url, entry.css('.views-field-view-node a/@href').text).to_s
   end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -10,23 +10,5 @@ class MembersPage < ScrapedPage
     URI.join(url, entry.css('.views-field-view-node a/@href').text).to_s
   end
 
-  def party_name(entry)
-    split_party(entry).first
-  end
-
-  def party_id(entry)
-    split_party(entry).last
-  end
-
-
-  private
-
-  def split_party(entry)
-    @split_party ||= entry
-                     .css('span.views-field-field-political-party .field-content')
-                     .text
-                     .strip
-                     .match(/(.*) \((.*)\)/)
-                     .captures
   end
 end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -32,6 +32,10 @@ class MembersPage < ScrapedPage
     entry.css('div.field-content img/@src').text
   end
 
+  def constituency(entry)
+    entry.css('span.views-field-field-constituency-name .field-content').text.strip
+  end
+
   private
 
   def split_party(entry)

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -18,10 +18,6 @@ class MembersPage < ScrapedPage
     split_party(entry).last
   end
 
-  def photo(entry)
-    entry.css('div.field-content img/@src').text
-  end
-
   def constituency(entry)
     entry.css('span.views-field-field-constituency-name .field-content').text.strip
   end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -9,6 +9,4 @@ class MembersPage < ScrapedPage
   def mp_url(entry)
     URI.join(url, entry.css('.views-field-view-node a/@href').text).to_s
   end
-
-  end
 end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -18,9 +18,6 @@ class MembersPage < ScrapedPage
     split_party(entry).last
   end
 
-  def constituency(entry)
-    entry.css('span.views-field-field-constituency-name .field-content').text.strip
-  end
 
   private
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -38,10 +38,9 @@ pages.each do |page|
 
   page.mp_entries.each do |entry|
     mp_url = page.mp_url(entry)
-    mp     = MemberPage.new(url: mp_url)
+    mp     = MemberPage.new(url: mp_url, entry: entry)
 
     data = {
-      name:         page.name(entry),
       photo:        page.photo(entry),
       constituency: page.constituency(entry),
       party:        page.party_name(entry),

--- a/scraper.rb
+++ b/scraper.rb
@@ -38,7 +38,7 @@ pages.each do |page|
   page = MembersPage.new(url: url)
 
   page.mp_entries.each do |entry|
-    mp_url = @BASE + entry.css('.views-field-view-node a/@href').text
+    mp_url = page.mp_url(entry)
 
     mp = noko(mp_url)
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -41,8 +41,6 @@ pages.each do |page|
     mp     = MemberPage.new(url: mp_url, entry: entry)
 
     data = {
-      party:        page.party_name(entry),
-      party_id:     page.party_id(entry),
       source:       url,
       term:         2011,
     }.merge(mp.to_h)

--- a/scraper.rb
+++ b/scraper.rb
@@ -20,19 +20,18 @@ def datefrom(date)
   Date.parse(date)
 end
 
-@BASE = 'http://www.parliament.gov.zm'
+base = 'http://www.parliament.gov.zm'
 
-# We should really extract these from the 'Next' links…
+# We should really extract these from the 'Next' links...
 pages = [
   '/members-of-parliament',
   '/members-of-parliament/page/1/0',
   '/members-of-parliament/page/2/0',
 ]
 
-
 added = 0
 pages.each do |page|
-  url = @BASE + page
+  url = base + page
   warn "Fetching #{url}"
 
   page = MembersPage.new(url: url)
@@ -41,23 +40,17 @@ pages.each do |page|
     mp_url = page.mp_url(entry)
     mp     = MemberPage.new(url: mp_url)
 
-    party_name = page.party_name(entry)
-    party_id   = page.party_id(entry)
-
     data = {
       name:         page.name(entry),
       photo:        page.photo(entry),
       constituency: page.constituency(entry),
-      party:        party_name,
-      party_id:     party_id,
-      source: url,
-      term: 2011,
+      party:        page.party_name(entry),
+      party_id:     page.party_id(entry),
+      source:       url,
+      term:         2011,
     }.merge(mp.to_h)
-    # puts data
-    ScraperWiki.save_sqlite([:name, :term], data)
+    ScraperWiki.save_sqlite(%i(name term), data)
     added += 1
   end
 end
 puts "  Added #{added}"
-
-

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,21 +1,20 @@
 #!/bin/env ruby
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'scraperwiki'
 require 'nokogiri'
 require 'date'
 require 'open-uri'
-require 'date'
+require 'pry'
 
-# require 'colorize'
-# require 'pry'
-# require 'csv'
-# require 'open-uri/cached'
-# OpenURI::Cache.cache_path = '.cache'
+require 'require_all'
+require_all 'lib'
 
-def noko(url)
-  Nokogiri::HTML(open(url).read) 
-end
+# require 'colorize'
+# require 'csv'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
 
 def datefrom(date)
   Date.parse(date)
@@ -36,9 +35,9 @@ pages.each do |page|
   url = @BASE + page
   warn "Fetching #{url}"
 
-  page = noko(url)
+  page = MembersPage.new(url: url)
 
-  page.css('div.view-members-of-parliament div.panel-display').each do |entry|
+  page.mp_entries.each do |entry|
     mp_url = @BASE + entry.css('.views-field-view-node a/@href').text
 
     mp = noko(mp_url)

--- a/scraper.rb
+++ b/scraper.rb
@@ -41,7 +41,6 @@ pages.each do |page|
     mp     = MemberPage.new(url: mp_url, entry: entry)
 
     data = {
-      constituency: page.constituency(entry),
       party:        page.party_name(entry),
       party_id:     page.party_id(entry),
       source:       url,

--- a/scraper.rb
+++ b/scraper.rb
@@ -48,7 +48,7 @@ pages.each do |page|
     data = { 
       id: mp_url.split('/').last,
       name:         page.name(entry),
-      photo: entry.css('div.field-content img/@src').text,
+      photo:        page.photo(entry),
       constituency: entry.css('span.views-field-field-constituency-name .field-content').text.strip,
       party:        party_name,
       email: mp.css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]').text.strip,

--- a/scraper.rb
+++ b/scraper.rb
@@ -39,14 +39,12 @@ pages.each do |page|
 
   page.mp_entries.each do |entry|
     mp_url = page.mp_url(entry)
-
-    mp = noko(mp_url)
+    mp     = MemberPage.new(url: mp_url)
 
     party_name = page.party_name(entry)
     party_id   = page.party_id(entry)
 
-    data = { 
-      id: mp_url.split('/').last,
+    data = {
       name:         page.name(entry),
       photo:        page.photo(entry),
       constituency: page.constituency(entry),
@@ -56,7 +54,7 @@ pages.each do |page|
       party_id:     party_id,
       source: url,
       term: 2011,
-    }
+    }.merge(mp.to_h)
     # puts data
     ScraperWiki.save_sqlite([:name, :term], data)
     added += 1

--- a/scraper.rb
+++ b/scraper.rb
@@ -49,7 +49,6 @@ pages.each do |page|
       photo:        page.photo(entry),
       constituency: page.constituency(entry),
       party:        party_name,
-      email: mp.css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]').text.strip,
       birth_date: mp.css('.field-name-field-date .field-item .date-display-single/@content').text.split('T').first,
       party_id:     party_id,
       source: url,

--- a/scraper.rb
+++ b/scraper.rb
@@ -49,7 +49,7 @@ pages.each do |page|
       id: mp_url.split('/').last,
       name:         page.name(entry),
       photo:        page.photo(entry),
-      constituency: entry.css('span.views-field-field-constituency-name .field-content').text.strip,
+      constituency: page.constituency(entry),
       party:        party_name,
       email: mp.css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]').text.strip,
       birth_date: mp.css('.field-name-field-date .field-item .date-display-single/@content').text.split('T').first,

--- a/scraper.rb
+++ b/scraper.rb
@@ -47,7 +47,7 @@ pages.each do |page|
 
     data = { 
       id: mp_url.split('/').last,
-      name: entry.css('.views-field-view-node a').text.split(/\s+/).join(" ").strip.gsub(/\s*,\s*MP\s*$/, ''),
+      name:         page.name(entry),
       photo: entry.css('div.field-content img/@src').text,
       constituency: entry.css('span.views-field-field-constituency-name .field-content').text.strip,
       party:        party_name,

--- a/scraper.rb
+++ b/scraper.rb
@@ -31,7 +31,8 @@ pages.each do |page|
   page.mp_entries.each do |entry|
     mp_url = page.mp_url(entry)
     mp     = MemberPage.new(url: mp_url, entry: entry)
-    ScraperWiki.save_sqlite(%i(name term), mp.to_h)
+    member = MemberEntry.new(url: url, noko: entry)
+    ScraperWiki.save_sqlite(%i(name term), mp.to_h.merge(member.to_h))
     added += 1
   end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -49,7 +49,6 @@ pages.each do |page|
       photo:        page.photo(entry),
       constituency: page.constituency(entry),
       party:        party_name,
-      birth_date: mp.css('.field-name-field-date .field-item .date-display-single/@content').text.split('T').first,
       party_id:     party_id,
       source: url,
       term: 2011,

--- a/scraper.rb
+++ b/scraper.rb
@@ -42,18 +42,18 @@ pages.each do |page|
 
     mp = noko(mp_url)
 
-    party = entry.css('span.views-field-field-political-party .field-content').text.strip
-    (party_name, party_id) = party.match(/(.*) \((.*)\)/).captures
+    party_name = page.party_name(entry)
+    party_id   = page.party_id(entry)
 
     data = { 
       id: mp_url.split('/').last,
       name: entry.css('.views-field-view-node a').text.split(/\s+/).join(" ").strip.gsub(/\s*,\s*MP\s*$/, ''),
       photo: entry.css('div.field-content img/@src').text,
       constituency: entry.css('span.views-field-field-constituency-name .field-content').text.strip,
-      party: party_name,
+      party:        party_name,
       email: mp.css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]').text.strip,
       birth_date: mp.css('.field-name-field-date .field-item .date-display-single/@content').text.split('T').first,
-      party_id: party_id,
+      party_id:     party_id,
       source: url,
       term: 2011,
     }

--- a/scraper.rb
+++ b/scraper.rb
@@ -41,7 +41,6 @@ pages.each do |page|
     mp     = MemberPage.new(url: mp_url, entry: entry)
 
     data = {
-      photo:        page.photo(entry),
       constituency: page.constituency(entry),
       party:        page.party_name(entry),
       party_id:     page.party_id(entry),

--- a/scraper.rb
+++ b/scraper.rb
@@ -39,12 +39,7 @@ pages.each do |page|
   page.mp_entries.each do |entry|
     mp_url = page.mp_url(entry)
     mp     = MemberPage.new(url: mp_url, entry: entry)
-
-    data = {
-      source:       url,
-      term:         2011,
-    }.merge(mp.to_h)
-    ScraperWiki.save_sqlite(%i(name term), data)
+    ScraperWiki.save_sqlite(%i(name term), mp.to_h)
     added += 1
   end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -12,28 +12,20 @@ require_all 'lib'
 # require 'open-uri/cached'
 # OpenURI::Cache.cache_path = '.cache'
 
-base = 'http://www.parliament.gov.zm'
-
-# We should really extract these from the 'Next' links...
-pages = [
-  '/members-of-parliament',
-  '/members-of-parliament/page/1/0',
-  '/members-of-parliament/page/2/0',
-]
-
+page  = MembersPage.new(url: 'http://www.parliament.gov.zm/members-of-parliament')
 added = 0
-pages.each do |page|
-  url = base + page
-  warn "Fetching #{url}"
 
-  page = MembersPage.new(url: url)
-
+loop do
   page.mp_entries.each do |entry|
     mp_url = page.mp_url(entry)
     mp     = MemberPage.new(url: mp_url)
-    member = MemberEntry.new(url: url, noko: entry)
+    member = MemberEntry.new(url: mp_url, noko: entry)
     ScraperWiki.save_sqlite(%i(name term), mp.to_h.merge(member.to_h))
     added += 1
   end
+  next_url = page.next_page_url
+  break unless next_url
+  page = MembersPage.new(url: next_url)
 end
+
 puts "  Added #{added}"

--- a/scraper.rb
+++ b/scraper.rb
@@ -4,21 +4,13 @@
 
 require 'scraperwiki'
 require 'nokogiri'
-require 'date'
-require 'open-uri'
 require 'pry'
 
 require 'require_all'
 require_all 'lib'
 
-# require 'colorize'
-# require 'csv'
 # require 'open-uri/cached'
 # OpenURI::Cache.cache_path = '.cache'
-
-def datefrom(date)
-  Date.parse(date)
-end
 
 base = 'http://www.parliament.gov.zm'
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -30,7 +30,7 @@ pages.each do |page|
 
   page.mp_entries.each do |entry|
     mp_url = page.mp_url(entry)
-    mp     = MemberPage.new(url: mp_url, entry: entry)
+    mp     = MemberPage.new(url: mp_url)
     member = MemberEntry.new(url: url, noko: entry)
     ScraperWiki.save_sqlite(%i(name term), mp.to_h.merge(member.to_h))
     added += 1


### PR DESCRIPTION
This PR rewrites the actual behaviour of the scraper to use the scraped page gem. I moved the code from the scraper to the relevant classes.

Since the data of a politician was half in the members page and half in the dedicated member page, the scraping of the entry is represented by a class as well as the scraping of the dedicated member's page, its hash merged with the dedicated page hash.

# Checklists

* [x] scraper is on Morph.io under the "everypolitician-scrapers" group <https://morph.io/everypolitician-scrapers/zambia-na-scraper>
* [x] scraper's GitHub "Website" link points at morph.io page <https://github.com/everypolitician-scrapers/zambia-na-scraper>
* [x] scraper is set to auto-run <https://morph.io/everypolitician-scrapers/zambia-na-scraper/settings>
* [x] scraper is configured for archiving _(unless source doesn't require that)_
* [ ] ~legislature has a scraper webhook set _(usually only set on Wikidata person-data scrapers)_~ Not needed


## Archiving

* [x] we are using at least version 0.5 of scraped-page-archive-gem
* [x] scraper uses scraped-page-archive gem directly or via a suitable strategy
* [x] MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured
* [x] pages are being archived in new branch of correct scraper repo <https://github.com/everypolitician-scrapers/zambia-na-scraper/tree/scraped-pages-archive/www.parliament.gov.zm>

## Gemfile

* [x] all links are secure
* [x] links to Github use `github:` protocol, not simply `git:`
* [x] file passes Rubocop with our normal setup (in particular, single quotes rather than double)
