### PR TITLE
Add scraped page archive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby '2.0.0'
 
-gem 'scraperwiki', git:    'https://github.com/openaustralia/scraperwiki-ruby',
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
 gem 'nokogiri'
 gem 'open-uri-cached'

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # gem "rails"
 # It's easy to add more libraries or choose different versions. Any libraries
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
-source "https://rubygems.org"
+source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby "2.0.0"
+ruby '2.0.0'
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby", branch: "morph_defaults"
-gem "nokogiri"
-gem "open-uri-cached"
+gem 'scraperwiki', git:    'https://github.com/openaustralia/scraperwiki-ruby',
+                   branch: 'morph_defaults'
+gem 'nokogiri'
+gem 'open-uri-cached'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+# gem "rails"
+# It's easy to add more libraries or choose different versions. Any libraries
+# specified here will be installed and made available to your morph.io scraper.
+# Find out more: https://morph.io/documentation/ruby
+source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
+ruby "2.0.0"
+
+gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby", branch: "morph_defaults"
+gem "nokogiri"
+gem "open-uri-cached"
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
       vcr-archive (~> 0.3.0)
 
 GIT
-  remote: https://github.com/openaustralia/scraperwiki-ruby
+  remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,59 @@
+GIT
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
+  specs:
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
+  remote: https://github.com/openaustralia/scraperwiki-ruby
+  revision: fc50176812505e463077d5c673d504a6a234aa78
+  branch: morph_defaults
+  specs:
+    scraperwiki (3.0.1)
+      httpclient
+      sqlite_magic
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
+    httpclient (2.8.2.4)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    open-uri-cached (0.0.5)
+    public_suffix (2.0.4)
+    safe_yaml (1.0.4)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
+      sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri
+  open-uri-cached
+  scraped_page_archive!
+  scraperwiki!
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.5

--- a/scraper.rb
+++ b/scraper.rb
@@ -12,6 +12,7 @@ require 'date'
 # require 'csv'
 # require 'open-uri/cached'
 # OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko(url)
   Nokogiri::HTML(open(url).read) 


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped.

## Why is this needed?

The country recently had an election coming up (2016-09-04). I hoped that we might be able to archive the previous term before it disappears but it looks like the site now lists the current term. As I had already begun to add the scraper, archiving the current term was only a trivial step -- at least it's now archived for the future.

Archiving it now gives us the chance to go back and re-scrape later even if it disappears.

## Relevant Issue(s):

https://github.com/everypolitician/everypolitician-data/issues/20544

## Checklists:

### Scraper change:
* [x] scraper is on Morph.io under the "everypolitician-scrapers" group
* [x] scraper's GitHub "Website" link points at morph.io page 
* [x] scraper is set to auto-run
* [ ] scraper is configured for archiving

### Adding Archiving:
* [x] scraper uses scraped-page-archive gem directly or via a suitable strategy — uses it directly
* [x] MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured
* [x] pages are being archived in new branch of correct scraper repo (yay!)

### Gemfile change:
* [x] all links are secure
* [x] links to Github use `github:` protocol, not simply `git:`
* [x] formatting is consistent with our normal Rubocop setup