### PR TITLE
Archive new term

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -18,7 +18,7 @@ def datefrom(date)
   Date.parse(date)
 end
 
-@BASE = 'http://www.parliament.gov.zm'
+BASE = 'http://www.parliament.gov.zm'
 
 # We should really extract these from the 'Next' links
 pages = [
@@ -29,13 +29,13 @@ pages = [
 
 added = 0
 pages.each do |page|
-  url = @BASE + page
+  url = URI.join(BASE, page)
   warn "Fetching #{url}"
 
   page = noko(url)
 
   page.css('div.view-members-of-parliament div.panel-display').each do |entry|
-    mp_url = @BASE + entry.css('.views-field-view-node a/@href').text
+    mp_url = URI.join(BASE, entry.css('.views-field-view-node a/@href').text)
 
     mp = noko(mp_url)
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -45,7 +45,7 @@ pages.each do |page|
     (party_name, party_id) = party.match(/(.*) \((.*)\)/).captures
 
     data = {
-      id:           mp_url.split('/').last,
+      id:           mp_url.to_s.split('/').last,
       name:         entry.css('.views-field-view-node a').text.split(/\s+/).join(' ').strip.gsub(/\s*,\s*MP\s*$/, ''),
       photo:        entry.css('div.field-content img/@src').text,
       constituency: entry.css('span.views-field-field-constituency-name .field-content').text.strip,
@@ -53,8 +53,8 @@ pages.each do |page|
       email:        mp.css('.field-name-field-email .field-item a[@href*="parliament.gov.zm"]').text.strip,
       birth_date:   mp.css('.field-name-field-date .field-item .date-display-single/@content').text.split('T').first,
       party_id:     party_id,
-      source:       url,
-      term:         2011,
+      source:       url.to_s,
+      term:         2016,
     }
     # puts data
     ScraperWiki.save_sqlite(%i(name term), data)

--- a/scraper.rb
+++ b/scraper.rb
@@ -6,6 +6,7 @@ require 'date'
 require 'nokogiri'
 require 'open-uri'
 require 'scraperwiki'
+require 'scraped_page_archive/open-uri'
 
 # require 'open-uri/cached'
 # OpenURI::Cache.cache_path = '.cache'

--- a/scraper.rb
+++ b/scraper.rb
@@ -26,6 +26,7 @@ pages = [
   '/members-of-parliament',
   '/members-of-parliament/page/1/0',
   '/members-of-parliament/page/2/0',
+  '/members-of-parliament/page/3/0'
 ]
 
 added = 0


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped.

## Why is this needed?

The country recently had an election coming up (2016-09-04). I hoped that we might be able to archive the previous term before it disappears but it looks like the site now lists the current term. As I had already begun to add the scraper, archiving the current term was only a trivial step -- at least it's now archived for the future.

Archiving it now gives us the chance to go back and re-scrape later even if it disappears.

## Checklists:

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [x] 1. scraper is on Morph.io under the "everypolitician-scrapers" group?
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* [x] 4. scraper is archiving?
* [x] 5. legislature has a scraper webhook set?

### Adding Archiving:
* [x] 1. we are using at least version 0.5 of scraped_page_archive gem?
* [x] 2. scraper uses scraped_page_archive gem directly or via a suitable strategy?
* [x] 3. MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured?
* [x] 4. pages are being archived in new branch of correct scraper repo?