### PR TITLE
Add dummy test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '2.3.3'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'minitest'
+gem 'minitest-around'
 gem 'minitest-vcr'
 gem 'nokogiri'
 gem 'open-uri-cached'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
     minispec-metadata (2.0.0)
       minitest
     minitest (5.10.1)
+    minitest-around (0.4.0)
+      minitest (~> 5.0)
     minitest-vcr (1.4.0)
       minispec-metadata (~> 2.0)
       minitest (>= 4.7.5)
@@ -87,6 +89,7 @@ PLATFORMS
 
 DEPENDENCIES
   minitest
+  minitest-around
   minitest-vcr
   nokogiri
   open-uri-cached

--- a/test/dummy_test.rb
+++ b/test/dummy_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+describe 'dummy test' do
+  it 'should run' do
+    # This test is included to ensure that
+    # test_helper is run by Travis
+  end
+end


### PR DESCRIPTION
This test requires `test_helper` to ensure that it is checked by Travis.

The gemfile has been updated to include `minitest-around`